### PR TITLE
Fix bug with egrep and tab character.

### DIFF
--- a/dvc.sh
+++ b/dvc.sh
@@ -20,7 +20,7 @@ add() {
     cp -p "$1" "${DVCSH}/objects/${sha}"
 
     if [ -f "${DVCSH}/index" ]; then
-        egrep -v "\t${file}\$" "${DVCSH}/index" >> "${DVCSH}/index.tmp"
+        egrep -v "$(printf '\t')${file}\$" "${DVCSH}/index" >> "${DVCSH}/index.tmp"
     fi
     printf "${sha}\t${file}\n" >> "${DVCSH}/index.tmp"
     mv "${DVCSH}/index.tmp" "${DVCSH}/index"


### PR DESCRIPTION
`egrep` does not support '\t', causing the `add` function to not work correctly. This patch fixes this.